### PR TITLE
exts/Makefile.inc: avoid unnecessary `cd`

### DIFF
--- a/cp2k/exts/Makefile.inc
+++ b/cp2k/exts/Makefile.inc
@@ -1,8 +1,9 @@
 
 LIBS += -L$(LIBEXTSDIR)/dbcsr -ldbcsr
 dbcsr: 
-	+cd $(EXTSHOME)/$@ ; \
-	$(MAKE) INCLUDEMAKE=$(CP2KHOME)/arch/$(ARCH).$(ONEVERSION) \
-	   LIBDIR=$(LIBEXTSDIR)/$@ OBJDIR=$(OBJEXTSDIR)/$@
-	@cp $(OBJEXTSDIR)/$@/dbcsr_api.mod $(OBJDIR)
-	@cp $(OBJEXTSDIR)/$@/dbcsr_tensor_api.mod $(OBJDIR)
+	$(MAKE) -C $(EXTSHOME)/$@ \
+	   INCLUDEMAKE=$(CP2KHOME)/arch/$(ARCH).$(ONEVERSION) \
+	   LIBDIR=$(LIBEXTSDIR)/$@ \
+	   OBJDIR=$(OBJEXTSDIR)/$@
+	@cp $(OBJEXTSDIR)/$@/dbcsr_api.mod $(OBJDIR)/
+	@cp $(OBJEXTSDIR)/$@/dbcsr_tensor_api.mod $(OBJDIR)/


### PR DESCRIPTION
... and make sure the target of the copy is always treated as a directory.